### PR TITLE
Fix autoload functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ WORKDIR ${dir}
 
 USER app
 
-RUN composer require -o jwplayer/jwplatform
+RUN composer require jwplayer/jwplatform
 
 CMD [ "php", "examples/upload_video.php" ]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ PHP 5.6.0 and later.
 You can install the bindings via [Composer](http://getcomposer.org/). Run the following command:
 
 ```bash
-composer require -o jwplayer/jwplatform
+composer require jwplayer/jwplatform
 ```
 
 To use the bindings, use Composer's [autoload](https://getcomposer.org/doc/01-basic-usage.md#autoloading):

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "jwplayer/jwplatform",
     "type": "library",
-    "description": "Official JW Player PHP API Adapter",
-    "version": "v1.6.2",
+    "description": "Official JW Player client",
+    "version": "v1.6.3",
     "keywords": [
       "jwplayer",
       "jwplatform",
@@ -22,9 +22,6 @@
     "require": {
       "php": ">=5.6.0",
       "ext-curl": "*"
-    },
-    "config": {
-      "optimize-autoloader": true
     },
     "autoload": {
         "psr-4": {

--- a/init.php
+++ b/init.php
@@ -1,3 +1,3 @@
 <?php
 // API client
-require(dirname(__FILE__) . '/src/Client.php');
+require(dirname(__FILE__) . '/src/JwplatformAPI.php');

--- a/src/JwplatformAPI.php
+++ b/src/JwplatformAPI.php
@@ -3,7 +3,7 @@
 namespace Jwplayer;
 
     class JwplatformAPI {
-        private $_version = '1.6.2';
+        private $_version = '1.6.3';
         private $_url = 'https://api.jwplatform.com/v1';
         private $_library;
 


### PR DESCRIPTION
Rename `Client.php` to comply with https://www.php-fig.org/psr/psr-4/ so that the `-o` option is not required.